### PR TITLE
Remove path from default url for sdx-sequence

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -17,7 +17,7 @@ APP_TMP = os.path.join(APP_ROOT, 'tmp')
 # Default to true, cast to boolean
 SDX_STORE_URL = os.getenv("SDX_STORE_URL", "http://sdx-store:5000")
 SDX_TRANSFORM_TESTFORM_URL = os.getenv("SDX_TRANSFORM_TESTFORM_URL", "http://sdx-transform-testform:5000")
-SDX_SEQUENCE_URL = os.getenv("SDX_SEQUENCE_URL", "http://sdx-sequence:5000/ctp-sequence")
+SDX_SEQUENCE_URL = os.getenv("SDX_SEQUENCE_URL", "http://sdx-sequence:5000")
 
 FTP_HOST = os.getenv('FTP_HOST', 'pure-ftpd')
 FTP_USER = os.getenv('FTP_USER')


### PR DESCRIPTION
This was proven wrong in testing, adjusted in the Jenkins job and the default never got updated.