### PR TITLE
Remove unused codacy file

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,0 @@
-codecov:
-  branch: develop


### PR DESCRIPTION
## What? and Why?
  -  Removes .codacy.yml pointing at the wrong branch
