### PR TITLE
Remove SDX_HOME and add release tag to travis for sdx-common

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.5"
   - "3.4"
 before_install:
-  - git clone https://github.com/ONSdigital/sdx-common.git
+  - git clone --branch 0.7.0 https://github.com/ONSdigital/sdx-common.git
   - pip3 install ./sdx-common
 install:
   - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 python:
   - "3.5"
   - "3.4"
-before_install:
-  - git clone --branch 0.7.0 https://github.com/ONSdigital/sdx-common.git
-  - pip3 install ./sdx-common
 install:
   - make build
   - pip install codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### Unreleased
-  - Remove SDX_HOME variable in makefile and add release tag to travis sdx-common clone
+  - Remove SDX_HOME variable in makefile and add release tag to sdx-common clone
 
 ### 2.1.0 2017-07-10
   - Update timestamp in all logs as UTC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Remove SDX_HOME variable in makefile and add release tag to travis sdx-common clone
 
 ### 2.1.0 2017-07-10
   - Update timestamp in all logs as UTC
@@ -7,7 +8,7 @@
   - Add environment variables to README
   - Add correct license attribution
   - Add codacy badge
-  - Add support for codecov to see unit test coverage 
+  - Add support for codecov to see unit test coverage
   - Add logging binary filename before attempting delivery
   - Fix incorrect git merge in Dockerfile and requirements.txt
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ dev: check-env
 	pip3 install -r requirements.txt
 
 build:
+	git clone --branch 0.7.0 https://github.com/ONSdigital/sdx-common.git
+	pip3 install ./sdx-common
 	pip3 install -r requirements.txt
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,3 @@ test:
 
 start:
 	./startup.sh
-
-check-env:
-ifeq ($(SDX_HOME),)
-	$(error SDX_HOME is not set)
-endif


### PR DESCRIPTION
## What? and Why?
> What does this pull request change/fix? Why was it nessessary?
Removes use of environment variable SDX_HOME  in makefile that causes issues in travis and add release tag to sdx-common clone in travis.

## Checklist
  - CHANGELOG.md updated?
